### PR TITLE
Remove version from show-plugin btest in prep for Bro 2.7

### DIFF
--- a/tests/af_xdp/show-plugin.bro
+++ b/tests/af_xdp/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN irtimmer::AF_XDP >output
+# @TEST-EXEC: bro -NN irtimmer::AF_XDP |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.